### PR TITLE
ci: wire wfctl plugin verify-capabilities + bump wfctl pin to v0.63.1 (workflow#765)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install wfctl v0.62.0
+      - name: Install wfctl v0.63.1
         run: |
           mkdir -p "${RUNNER_TEMP}/wfctl-bin"
           curl -sSfL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -o "${RUNNER_TEMP}/wfctl-bin/wfctl" \
-            "https://github.com/GoCodeAlone/workflow/releases/download/v0.62.0/wfctl-linux-amd64"
+            "https://github.com/GoCodeAlone/workflow/releases/download/v0.63.1/wfctl-linux-amd64"
           chmod +x "${RUNNER_TEMP}/wfctl-bin/wfctl"
       - name: Validate plugin contract for publish (pre-build)
         run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag ${{ github.ref_name }} ."
@@ -50,6 +50,19 @@ jobs:
     needs: [release]
     runs-on: ubuntu-latest
     steps:
+      # workflow#765: runtime truth-check via plugin verify-capabilities.
+      - name: Verify capabilities (runtime truth-check)
+        run: |
+          RUNNER_ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          BIN=$(jq -r --arg arch "$RUNNER_ARCH" \
+            '[.[] | select(.type=="Binary" and .goos=="linux" and .goarch==$arch and (.name|startswith("workflow-plugin-slack")))] | .[0].path // ""' \
+            dist/artifacts.json)
+          if [ -z "$BIN" ] || [ "$BIN" = "null" ]; then
+            echo "::warning::No matching linux/$RUNNER_ARCH binary in dist/artifacts.json; skipping verify-capabilities"
+            jq '.[] | {name, type, goos, goarch, path}' dist/artifacts.json
+            exit 0
+          fi
+          "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
       - name: Publish GitHub release
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Layer 3b extension from workflow#765 sweep. Adds post-goreleaser `wfctl plugin verify-capabilities` step to release.yml; bumps Install wfctl pin v0.62.0 → v0.63.1 (carries the new subcommand). jq filter selects this plugin's linux/<runner-arch> binary from `dist/artifacts.json`; skip-with-warning if no match.

Closes the runtime truth-loop on releases: validate-contract (static) + verify-capabilities (runtime) confirm both the source-tree shape AND the actual built binary's GetManifest match plugin.json.