### PR TITLE
chore: bump plugin.json to v0.1.2 + update download URLs

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -40,22 +40,22 @@
         {
             "os": "linux",
             "arch": "amd64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.1/workflow-plugin-slack-linux-amd64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.2/workflow-plugin-slack-linux-amd64.tar.gz"
         },
         {
             "os": "linux",
             "arch": "arm64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.1/workflow-plugin-slack-linux-arm64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.2/workflow-plugin-slack-linux-arm64.tar.gz"
         },
         {
             "os": "darwin",
             "arch": "amd64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.1/workflow-plugin-slack-darwin-amd64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.2/workflow-plugin-slack-darwin-amd64.tar.gz"
         },
         {
             "os": "darwin",
             "arch": "arm64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.1/workflow-plugin-slack-darwin-arm64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.2/workflow-plugin-slack-darwin-arm64.tar.gz"
         }
     ]
 }


### PR DESCRIPTION
Post-release cleanup: bump download URLs to v0.1.2 (version field already at 0.1.2).