### PR TITLE
fix(release): fix action versions and ldflag package path (v0.1.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,14 @@ jobs:
   release:
     runs-on: [self-hosted, Linux, X64]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Configure git for private modules
         run: git config --global url."https://${{ secrets.RELEASES_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.version={{.Version}} -X github.com/GoCodeAlone/workflow-plugin-slack/internal.Version={{.Version}}
+      - -s -w -X github.com/GoCodeAlone/workflow-plugin-slack/internal.Version={{.Version}}
 
 archives:
   - formats: [tar.gz]


### PR DESCRIPTION
## Summary
- actions/checkout@v6 and actions/setup-go@v6 do not exist; downgraded to @v4 and @v5
- Removed non-existent main.version ldflag (only internal.Version exists)

## Root cause
The release workflow was referencing non-existent action versions which would fail on GitHub-hosted runners. The ldflag referenced a non-existent main.version variable.