### PR TITLE
ci(release): runs-on ubuntu-latest (match fleet pattern)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   release:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Was: `[self-hosted, Linux, X64]` — but no org/repo self-hosted runner picks up these jobs (queued 3+ hours). Every other plugin in the GoCodeAlone fleet uses `ubuntu-latest`; aligns this repo with that pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)