### PR TITLE
fix(release): collapse notify-registry into release job + use listReleases for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  notify-registry:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [release]
-    runs-on: ubuntu-latest
-    steps:
       # workflow#765: runtime truth-check via plugin verify-capabilities.
+      # Stays in `release` job so dist/artifacts.json from goreleaser is accessible.
       - name: Verify capabilities (runtime truth-check)
         run: |
           RUNNER_ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
@@ -63,14 +59,17 @@ jobs:
             exit 0
           fi
           "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
+
       - name: Publish GitHub release
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.RELEASES_TOKEN || github.token }}
           script: |
-            const tag = process.env.GITHUB_REF_NAME;
+            const tag = context.ref.replace('refs/tags/', '');
             const { owner, repo } = context.repo;
-            const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
+            const release = releases.find(r => r.tag_name === tag);
+            if (!release) throw new Error(`No release found for tag ${tag}`);
             if (release.draft) {
               await github.rest.repos.updateRelease({
                 owner,


### PR DESCRIPTION
Resolves #16.

Was: `notify-registry` separate job → fresh runner → `dist/artifacts.json` not available → 'No such file or directory'. Plus Publish step used `getReleaseByTag` which 404s on drafts.

Now: `verify-capabilities` + `Publish GitHub release` + `Notify workflow-registry` all in the `release` job (same runner = dist accessible + draft visible to listReleases find).

🤖 Generated with [Claude Code](https://claude.com/claude-code)