### PR TITLE
fix: retry release draft publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,16 @@ jobs:
           script: |
             const tag = context.ref.replace('refs/tags/', '');
             const { owner, repo } = context.repo;
-            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
-            const release = releases.find(r => r.tag_name === tag);
+            // GoReleaser creates draft releases; listReleases sees drafts while
+            // getReleaseByTag can 404. Retry because the release can be
+            // eventually visible after asset uploads finish.
+            let release;
+            for (let attempt = 0; attempt < 12; attempt++) {
+              const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
+              release = releases.find(r => r.tag_name === tag);
+              if (release) break;
+              await new Promise(resolve => setTimeout(resolve, 5000));
+            }
             if (!release) throw new Error(`No release found for tag ${tag}`);
             if (release.draft) {
               await github.rest.repos.updateRelease({


### PR DESCRIPTION
## Summary\n- retry draft release lookup before publishing the GoReleaser-created draft\n- preserves the existing verify-capabilities and registry notification flow\n\n## Verification\n- GOWORK=off go test ./...\n- ruby YAML parse for .github/workflows/release.yml\n- actionlint .github/workflows/release.yml\n- git diff --check