### PR TITLE
chore: advertise required_secrets[] (SLACK_BOT_TOKEN, SLACK_APP_TOKEN)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -7,6 +7,20 @@
   "tier": "community",
   "license": "MIT",
   "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "SLACK_BOT_TOKEN",
+      "sensitive": true,
+      "description": "Slack bot token (xoxb-…). Referenced as ${SLACK_BOT_TOKEN}.",
+      "prompt": "Slack bot token"
+    },
+    {
+      "name": "SLACK_APP_TOKEN",
+      "sensitive": true,
+      "description": "Slack app-level token (xapp-…) for Socket Mode. Referenced as ${SLACK_APP_TOKEN}.",
+      "prompt": "Slack app token"
+    }
+  ],
   "keywords": [
     "slack",
     "messaging",


### PR DESCRIPTION
Advertise required_secrets[] so 'wfctl secrets setup --plugin slack' provisions credentials uniformly. Part of the ecosystem sweep (workspace docs/plans/2026-05-31-plugin-required-secrets-sweep*; ADR 0006). Source-of-truth mirror of the workflow-registry manifest. No release. Names verified per design §4. Copilot not requested (down).