### PR TITLE
ci: canonical registry notify (fix dead dispatch + drop manifest-overwrite)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,15 +87,23 @@ jobs:
               });
             }
 
-      - name: Notify workflow-registry
-        if: env.GH_TOKEN != ''
-        uses: peter-evans/repository-dispatch@v3
+
+  notify-workflow-registry:
+    name: Notify workflow-registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: release
+    if: >-
+      !github.event.deleted
+      && !contains(github.ref_name, '-')
+      && github.repository == 'GoCodeAlone/workflow-plugin-slack'
+    steps:
+      - name: Trigger registry manifest sync
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
         with:
-          token: ${{ secrets.REGISTRY_PAT }}
+          token: ${{ secrets.repo_dispatch_token }}
           repository: GoCodeAlone/workflow-registry
           event-type: plugin-release
-          client-payload: >-
-            {"plugin": "${{ github.repository }}", "tag": "${{ github.ref_name }}"}
-        env:
-          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
-        continue-on-error: true
+          client-payload: |-
+            {"plugin": "slack", "tag": "${{ github.ref_name }}"}


### PR DESCRIPTION
Replace the old in-job `Notify workflow-registry` step with the fleet-canonical `notify-workflow-registry` job.

**Changes:**
- Removes old step using `REGISTRY_PAT`, `peter-evans/repository-dispatch@v3`, `continue-on-error`, and full `github.repository` path in payload
- Adds dedicated `notify-workflow-registry` job with pinned action SHA (`v4`), `repo_dispatch_token`, bare plugin name `"slack"` in payload, and pre-release tag guard (`!contains(github.ref_name, '-')`)