### PR TITLE
Fix release validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,27 +17,45 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Configure git for private modules
         run: git config --global url."https://${{ secrets.RELEASES_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
-      - name: Install wfctl v0.63.2
+      - name: Install wfctl v0.78.0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WFCTL_VERSION: v0.78.0
         run: |
+          set -euo pipefail
+          runner_arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          asset="wfctl-linux-${runner_arch}"
+          download_dir="$(mktemp -d)"
+          case "${asset}" in
+            wfctl-linux-amd64) expected_sha="63ac0957274e702930045c9c49955ab2a80b2ee9660da04d4fb4a45c8217f7d2" ;;
+            wfctl-linux-arm64) expected_sha="47a7d380837e404e00930b2a4bc504d583bf606520bc58c29dc984d21e704929" ;;
+            *) echo "::error::unsupported wfctl asset ${asset}"; exit 1 ;;
+          esac
+          gh release download "${WFCTL_VERSION}" \
+            --repo GoCodeAlone/workflow \
+            --pattern "${asset}" \
+            --dir "${download_dir}"
+          actual_sha="$(sha256sum "${download_dir}/${asset}" | awk '{print $1}')"
+          if [ "${actual_sha}" != "${expected_sha}" ]; then
+            echo "::error::wfctl checksum mismatch for ${asset}: expected ${expected_sha}, got ${actual_sha}"
+            exit 1
+          fi
           mkdir -p "${RUNNER_TEMP}/wfctl-bin"
-          curl -sSfL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -o "${RUNNER_TEMP}/wfctl-bin/wfctl" \
-            "https://github.com/GoCodeAlone/workflow/releases/download/v0.63.2/wfctl-linux-amd64"
-          chmod +x "${RUNNER_TEMP}/wfctl-bin/wfctl"
+          install -m 0755 "${download_dir}/${asset}" "${RUNNER_TEMP}/wfctl-bin/wfctl"
       - name: Validate plugin contract for publish (pre-build)
         run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag ${{ github.ref_name }} ."
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -58,13 +76,14 @@ jobs:
             jq '.[] | {name, type, goos, goarch, path}' dist/artifacts.json
             exit 0
           fi
+          chmod +x -- "$BIN"
           "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
       - name: Verify shipped plugin.json carries tag (post-build)
         run: |
-          "${{ runner.temp }}/wfctl-bin/wfctl" plugin validate-contract --for-publish --tag ${{ github.ref_name }} --release-dir . .
+          "${{ runner.temp }}/wfctl-bin/wfctl" plugin validate-contract --for-publish --tag ${{ github.ref_name }} --release-dir .goreleaser-tmp .
 
       - name: Publish GitHub release
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.RELEASES_TOKEN || github.token }}
           script: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoCodeAlone/workflow-plugin-slack
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/GoCodeAlone/workflow v0.64.0


### PR DESCRIPTION
## Summary
- validate post-build contract checks against the GoReleaser-stamped manifest
- update release workflow to SHA-pinned current actions, Go 1.26.4, and checksum-verified wfctl v0.78.0
- preserve draft-release publish retry behavior

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok slack release.yml"'\n- git diff --check\n- GOWORK=off go test ./...